### PR TITLE
Solve labels-images association in embedding

### DIFF
--- a/tensorboard/embedding.py
+++ b/tensorboard/embedding.py
@@ -15,11 +15,17 @@ def make_sprite(label_img, save_path):
     import torch
     import torchvision
     # this ensure we have enought space for the images
-    base_size = int(math.ceil((label_img.size(0)) ** 0.5))
+    nrow = int(math.ceil((label_img.size(0)) ** 0.5))
     # cat the images to reach the square of base_size
-    label_img = torch.cat((label_img, torch.zeros(base_size ** 2 - label_img.size(0), *label_img.size()[1:])), 0)
-    # this call make_grid insied, but now we can ensure a square grid
-    torchvision.utils.save_image(label_img, os.path.join(save_path, 'sprite.png'), nrow=base_size, padding=0)
+    label_img = torch.cat((label_img, torch.randn(nrow ** 2 - label_img.size(0), *label_img.size()[1:]) * 255), 0)
+    # this ensure no pixel are appended by make_grid call in save_image (such a stupid function)
+    xx = torchvision.utils.make_grid(torch.Tensor(1, 3, 32, 32), padding=0)
+    if xx.size(2) == 33:  # https://github.com/pytorch/vision/issues/206
+        sprite = torchvision.utils.make_grid(label_img, nrow=nrow, padding=0)
+        sprite = sprite[:, 1:, 1:]
+        torchvision.utils.save_image(sprite, os.path.join(save_path, 'sprite.png'))
+    else:
+        torchvision.utils.save_image(label_img, os.path.join(save_path, 'sprite.png'), nrow=nrow, padding=0)
 
 
 def make_pbtxt(save_path, metadata, label_img):

--- a/tensorboard/embedding.py
+++ b/tensorboard/embedding.py
@@ -1,25 +1,26 @@
 import os
 
+
 def make_tsv(metadata, save_path):
     metadata = [str(x) for x in metadata]
     with open(os.path.join(save_path, 'metadata.tsv'), 'w') as f:
         for x in metadata:
-            f.write(x+'\n')
+            f.write(x + '\n')
 
 
 # https://github.com/tensorflow/tensorboard/issues/44 image label will be squared
 def make_sprite(label_img, save_path):
+    # we have to make labels_img squared!
     import math
     import torch
     import torchvision
-    nrow = int(math.floor(math.sqrt(label_img.size(0))))
-    xx = torchvision.utils.make_grid(torch.Tensor(1,3,32,32), padding=0)
-    if xx.size(2)==33: # https://github.com/pytorch/vision/issues/206
-        sprite = torchvision.utils.make_grid(label_img, nrow=nrow, padding=0)
-        sprite = sprite[:,1:,1:]
-        torchvision.utils.save_image(sprite, os.path.join(save_path, 'sprite.png'))
-    else:
-        torchvision.utils.save_image(label_img, os.path.join(save_path, 'sprite.png'), nrow=nrow, padding=0)
+    # this ensure we have enought space for the images
+    base_size = int(math.ceil((label_img.size(0)) ** 0.5))
+    # cat the images to reach the square of base_size
+    label_img = torch.cat((label_img, torch.zeros(base_size ** 2 - label_img.size(0), *label_img.size()[1:])), 0)
+    # this call make_grid insied, but now we can ensure a square grid
+    torchvision.utils.save_image(label_img, os.path.join(save_path, 'sprite.png'), nrow=base_size, padding=0)
+
 
 def make_pbtxt(save_path, metadata, label_img):
     with open(os.path.join(save_path, 'projector_config.pbtxt'), 'w') as f:
@@ -36,12 +37,13 @@ def make_pbtxt(save_path, metadata, label_img):
             f.write('}\n')
         f.write('}\n')
 
+
 def make_mat(matlist, save_path):
     with open(os.path.join(save_path, 'tensors.tsv'), 'w') as f:
         for x in matlist:
             x = [str(i) for i in x]
-            f.write('\t'.join(x)+'\n')
-            
+            f.write('\t'.join(x) + '\n')
+
 
 def add_embedding(mat, save_path, metadata=None, label_img=None):
     """add embedding
@@ -60,8 +62,8 @@ def add_embedding(mat, save_path, metadata=None, label_img=None):
         ~~This function needs tensorflow installed. It invokes tensorflow to dump data. ~~
         Therefore I separate it from the SummaryWriter class. Please pass ``writer.file_writer.get_logdir()`` to ``save_path`` to prevent glitches.
 
-        If ``save_path`` is different than SummaryWritter's save path, you need to pass the leave directory to tensorboard's logdir argument, 
-        otherwise it cannot display anything. e.g. if ``save_path`` equals 'path/to/embedding', 
+        If ``save_path`` is different than SummaryWritter's save path, you need to pass the leave directory to tensorboard's logdir argument,
+        otherwise it cannot display anything. e.g. if ``save_path`` equals 'path/to/embedding',
         you need to call 'tensorboard --logdir=path/to/embedding', instead of 'tensorboard --logdir=path'.
 
 
@@ -81,7 +83,7 @@ def add_embedding(mat, save_path, metadata=None, label_img=None):
         label_img = torch.rand(100, 3, 10, 32)
         for i in range(100):
             label_img[i]*=i/100.0
-            
+
         add_embedding(torch.randn(100, 5), 'embedding1', metadata=meta, label_img=label_img)
         add_embedding(torch.randn(100, 5), 'embedding2', label_img=label_img)
         add_embedding(torch.randn(100, 5), 'embedding3', metadata=meta)
@@ -91,12 +93,12 @@ def add_embedding(mat, save_path, metadata=None, label_img=None):
     except OSError:
         print('warning: dir exists')
     if metadata is not None:
-        assert mat.size(0)==len(metadata), '#labels should equal with #data points'
+        assert mat.size(0) == len(metadata), '#labels should equal with #data points'
         make_tsv(metadata, save_path)
     if label_img is not None:
-        assert mat.size(0)==label_img.size(0), '#images should equal with #data points'
+        assert mat.size(0) == label_img.size(0), '#images should equal with #data points'
         make_sprite(label_img, save_path)
-    assert mat.dim()==2, 'mat should be 2D, where mat.size(0) is the number of data points'
+    assert mat.dim() == 2, 'mat should be 2D, where mat.size(0) is the number of data points'
     make_mat(mat.tolist(), save_path)
     make_pbtxt(save_path, metadata, label_img)
 

--- a/tensorboard/embedding.py
+++ b/tensorboard/embedding.py
@@ -12,7 +12,8 @@ def make_sprite(label_img, save_path):
     import math
     import torch
     import torchvision
-    # this ensures the sprite image has enough space for the image labels
+    # this ensures the sprite image has correct dimension as described in 
+    # https://www.tensorflow.org/get_started/embedding_viz
     nrow = int(math.ceil((label_img.size(0)) ** 0.5))
     
     # augment images so that #images equals nrow*nrow
@@ -26,7 +27,6 @@ def make_sprite(label_img, save_path):
         torchvision.utils.save_image(sprite, os.path.join(save_path, 'sprite.png'))
     else:
         torchvision.utils.save_image(label_img, os.path.join(save_path, 'sprite.png'), nrow=nrow, padding=0)
-
 
 def make_pbtxt(save_path, metadata, label_img):
     with open(os.path.join(save_path, 'projector_config.pbtxt'), 'w') as f:
@@ -43,13 +43,11 @@ def make_pbtxt(save_path, metadata, label_img):
             f.write('}\n')
         f.write('}\n')
 
-
 def make_mat(matlist, save_path):
     with open(os.path.join(save_path, 'tensors.tsv'), 'w') as f:
         for x in matlist:
             x = [str(i) for i in x]
             f.write('\t'.join(x) + '\n')
-
 
 def add_embedding(mat, save_path, metadata=None, label_img=None):
     """add embedding


### PR DESCRIPTION
TB needs a squared sprite, even if the number of images is not a perfect square, so we need to ensure to always present a squared grid. If the number of images is not a perfect square (i.e 8 is not), the easiest way is to cat images (random noise will do the trick) to reach the nearest big square ( 9 in this case).