### PR TITLE
Make PIL import lazy

### DIFF
--- a/tensorboardX/summary.py
+++ b/tensorboardX/summary.py
@@ -38,7 +38,6 @@ import re as _re
 import bisect
 from six import StringIO
 from six.moves import range
-from PIL import Image
 import numpy as np
 # pylint: disable=unused-import
 from .src.summary_pb2 import Summary
@@ -160,6 +159,7 @@ def image(tag, tensor):
 
 def make_image(tensor):
     """Convert an numpy representation image to Image protobuf"""
+    from PIL import Image
     height, width, channel = tensor.shape
     image = Image.fromarray(tensor)
     import io

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -270,6 +270,8 @@ class SummaryWriter(object):
     def add_image(self, tag, img_tensor, global_step=None):
         """Add image data to summary.
 
+        Note that this requires the ``pillow`` package.
+
         Args:
             tag (string): Data identifier
             img_tensor (torch.Tensor): Image data


### PR DESCRIPTION
Currently import fails when PIL is not installed, this fixes it and adds a note for users.