### PR TITLE
implement the ctx manager protocol for SummaryWriter

### DIFF
--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -30,10 +30,6 @@ class RecordWriter(object):
         w(struct.pack('I', masked_crc32c(event_str)))
         self._writer.flush()
 
-    def __del__(self):
-        if self._writer is not None:
-            self._writer.close()
-
 
 def masked_crc32c(data):
     x = u32(crc32c(data))

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -430,14 +430,17 @@ class SummaryWriter(object):
         append_pbtxt(metadata, label_img, self.file_writer.get_logdir(), str(global_step).zfill(5), tag)
 
     def close(self):
+        if self.file_writer is None:
+            return  # ignore double close
         self.file_writer.flush()
         self.file_writer.close()
         for path, writer in self.all_writers.items():
             writer.flush()
             writer.close()
+        self.file_writer = self.all_writers = None
 
-    def __del__(self):
-        if self.file_writer is not None:
-            self.file_writer.close()
-        for writer in self.all_writers.values():
-            writer.close()
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/tests/test_summary_writer.py
+++ b/tests/test_summary_writer.py
@@ -1,0 +1,8 @@
+from tensorboardX import SummaryWriter
+
+
+def test_summary_writer_ctx():
+    # after using a SummaryWriter as a ctx it should be closed
+    with SummaryWriter() as writer:
+        writer.add_scalar('test', 1)
+    assert writer.file_writer is None


### PR DESCRIPTION
This makes `SummaryWriter` implement the context manager protocol, so that it can be used in `with` blocks like other file-like objects in Python. I've written a short test case.

I've also removed the `__del__` method on `SummaryWriter` and `RecordWriter`, since the existing implementations are not necessary (file objects already close themselves when deleted). Adding superfluous `__del__` methods adversely affects the Python GC.