### PR TITLE
makenp: allows passing a float as np.array

### DIFF
--- a/tensorboardX/x2num.py
+++ b/tensorboardX/x2num.py
@@ -7,6 +7,8 @@ def makenp(x, modality=None):
     if isinstance(x, np.ndarray):
         if modality == 'IMG' and x.dtype == np.uint8:
             return x.astype(np.float32)/255.0
+        if len(x.shape) == 0:
+            return x.reshape(1)
         return x
     if np.isscalar(x):
         return np.array([x])


### PR DESCRIPTION
When trying to summarize float numbers as np.array, this `x2num` gives a np.array of shape 0. Fixed this corner case.