### PR TITLE
fix isinstance() validation in pytorch

### DIFF
--- a/tensorboardX/x2num.py
+++ b/tensorboardX/x2num.py
@@ -21,7 +21,7 @@ def makenp(x, modality=None):
 
 def pytorch_np(x, modality):
     import torch
-    if isinstance(x, torch.autograd.variable.Variable):
+    if isinstance(x, torch.autograd.Variable):
         x = x.data
     x = x.cpu().numpy()
     if modality == 'IMG':


### PR DESCRIPTION
Solved this issue,
```  
File "/home/yokoo/.pyenv/versions/anaconda3-5.0.1/envs/py36/lib/python3.6/site-packages/tensorboardX/summary.py", line 155, in image
    tensor = makenp(tensor, 'IMG')
  File "/home/yokoo/.pyenv/versions/anaconda3-5.0.1/envs/py36/lib/python3.6/site-packages/tensorboardX/x2num.py", line 15, in makenp
    return pytorch_np(x, modality)
  File "/home/yokoo/.pyenv/versions/anaconda3-5.0.1/envs/py36/lib/python3.6/site-packages/tensorboardX/x2num.py", line 24, in pytorch_np
    if isinstance(x, torch.autograd.variable.Variable):
AttributeError: 'builtin_function_or_method' object has no attribute 'Variable'
```