### PR TITLE
PyTorch 0.3.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Write TensorBoard events with simple function call.
 
 * [Demo](http://35.197.26.245:6006)
 
-* `demo_graph.py` needs tensorboardX>=1.0, pytorch >=0.4 to work, so you have to build pytorch from source(commit newer than 040336f, which supports scoping).
+* `demo_graph.py` needs tensorboardX>=1.0 and pytorch>=0.3.1 to work (for scoping support).
 
 * [FAQ](https://github.com/lanpa/tensorboard-pytorch/wiki)
 

--- a/tensorboardX/graph.py
+++ b/tensorboardX/graph.py
@@ -42,7 +42,11 @@ def graph(model, args, verbose=False):
     import torch
     with torch.onnx.set_training(model, False):
         trace, _ = torch.jit.trace(model, args)
-    torch.onnx._optimize_trace(trace, False)
+    from distutils.version import LooseVersion
+    if LooseVersion(torch.__version__) >= LooseVersion("0.4"):
+        torch.onnx._optimize_trace(trace, False)
+    else:
+        torch.onnx._optimize_trace(trace)
     graph = trace.graph()
     if verbose:
         print(graph)

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -388,11 +388,11 @@ class SummaryWriter(object):
         """
         import torch
         from distutils.version import LooseVersion
-        if LooseVersion(torch.__version__) >= LooseVersion("0.4"):
+        if LooseVersion(torch.__version__) >= LooseVersion("0.3.1"):
             pass
         else:
-            if LooseVersion(torch.__version__) >= LooseVersion("0.3"):
-                print('You are using PyTorch==0.3, use add_graph_onnx()')
+            if LooseVersion(torch.__version__) >= LooseVersion("0.3.0"):
+                print('You are using PyTorch==0.3.0, use add_graph_onnx()')
                 return
             if not hasattr(torch.autograd.Variable, 'grad_fn'):
                 print('add_graph() only supports PyTorch v0.2.')


### PR DESCRIPTION
Looks like the newest release of pytorch should be able to work with `demo_graph.py`, since scoping has been backported (https://github.com/pytorch/pytorch/pull/5153) .