### PR TITLE
Change default bins in add_histogram from 'tensorflow' to 'auto'

### DIFF
--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -309,7 +309,7 @@ class SummaryWriter(object):
         with open(path, "w") as f:
             json.dump(self.scalar_dict, f)
 
-    def add_histogram(self, tag, values, global_step=None, bins='tensorflow'):
+    def add_histogram(self, tag, values, global_step=None, bins='auto'):
         """Add histogram to summary.
 
         Args:


### PR DESCRIPTION
The default bins of  'tensorflow' in add_histogram results in weird hist plots. The calculated range usually doesn't fit the data and extends from -1e20 to 1e20. As add_histogram is implemented by using numpy.histogram, changing to 'auto' can calculate the optimal bin width, which brings better experience by default.
