### PR TITLE
Add add_video to SummaryWriter

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -71,5 +71,9 @@ all_labels = list(zip(all_labels, dataset_label))
 writer.add_embedding(all_features, metadata=all_labels, label_img=all_images.unsqueeze(1),
                      metadata_header=['digit', 'dataset'], global_step=2)
 
+# VIDEO
+vid_images = dataset.train_data[:16*3*16]
+vid = vid_images.view(16, 3, 16, 28, 28)  # BxCxTxHxW
+writer.add_video('video', vid_tensor=vid)
 
 writer.close()

--- a/tensorboardX/summary.py
+++ b/tensorboardX/summary.py
@@ -175,6 +175,38 @@ def make_image(tensor):
                          encoded_image_string=image_string)
 
 
+def video(tag, tensor):
+    tag = _clean_tag(tag)
+    tensor = makenp(tensor, 'VID')
+    tensor = tensor.astype(np.float32)
+    tensor = (tensor * 255).astype(np.uint8)
+    video = make_video(tensor)
+    return Summary(value=[Summary.Value(tag=tag, image=video)])
+
+
+def make_video(tensor):
+    import moviepy.editor as mpy
+    import tempfile
+
+    t, h, w, c = tensor.shape
+
+    # encode sequence of images into gif string
+    clip = mpy.ImageSequenceClip(list(tensor), fps=4)
+    with tempfile.NamedTemporaryFile() as f:
+        filename = f.name + '.gif'
+
+    import sys
+    save_stdout = sys.stderr
+    sys.stderr = open('trash', 'w')
+    clip.write_gif(filename, verbose=False)
+    sys.stderr = save_stdout
+    with open(filename, 'rb') as f:
+        tensor_string = f.read()
+
+        log_video = Summary.Image(height=h, width=w, colorspace=c, encoded_image_string=tensor_string)
+    return log_video
+
+
 def audio(tag, tensor, sample_rate=44100):
     tensor = makenp(tensor)
     tensor = tensor.squeeze()

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -25,7 +25,7 @@ from .src import event_pb2
 from .src import summary_pb2
 from .src import graph_pb2
 from .event_file_writer import EventFileWriter
-from .summary import scalar, histogram, image, audio, text, pr_curve, pr_curve_raw
+from .summary import scalar, histogram, image, audio, text, pr_curve, pr_curve_raw, video
 from .graph import graph
 from .graph_onnx import gg
 from .embedding import make_mat, make_sprite, make_tsv, append_pbtxt
@@ -336,6 +336,21 @@ class SummaryWriter(object):
             img_tensor: :math:`(3, H, W)`. Use ``torchvision.utils.make_grid()`` to prepare it is a good idea.
         """
         self.file_writer.add_summary(image(tag, img_tensor), global_step)
+
+    def add_video(self, tag, vid_tensor, global_step=None):
+        """Add video data to summary.
+
+        Note that this requires the ``moviepy`` package.
+
+        Args:
+            tag (string): Data identifier
+            vid_tensor (torch.Tensor): Video data
+            global_step (int): Global step value to record
+        Shape:
+            vid_tensor: :math:`(B, C, T, H, W)`. 
+        """
+
+        self.file_writer.add_summary(video(tag, vid_tensor), global_step)
 
     def add_audio(self, tag, snd_tensor, global_step=None, sample_rate=44100):
         """Add audio data to summary.

--- a/tensorboardX/x2num.py
+++ b/tensorboardX/x2num.py
@@ -26,6 +26,9 @@ def pytorch_np(x, modality):
     x = x.cpu().numpy()
     if modality == 'IMG':
         x = _prepare_image(x)
+    if modality == 'VID':
+        x = _prepare_video(x)
+
     return x
 
 
@@ -88,3 +91,29 @@ def _prepare_image(I):
     I = I.transpose(1, 2, 0)
 
     return I
+
+
+def _prepare_video(V):
+
+    b, c, t, h, w = V.shape
+
+    if V.dtype == np.uint8:
+        V = np.float32(V) / 255.
+
+    def is_power2(num):
+        return num != 0 and ((num & (num - 1)) == 0)
+
+    # pad to power of 2
+    while not is_power2(V.shape[0]):
+        V = np.concatenate((V, np.zeros(shape=(1, c, t, h, w))), axis=0)
+
+    b = V.shape[0]
+    n_rows = 2**(int(np.log(b) / np.log(2)) // 2)
+    n_cols = b // n_rows
+
+    V = np.reshape(V, newshape=(n_rows, n_cols, c, t, h, w))
+    V = np.transpose(V, axes=(3, 0, 4, 1, 5, 2))
+    V = np.reshape(V, newshape=(t, n_rows * h, n_cols * w, c))
+
+    return V
+


### PR DESCRIPTION
I added the feature of logging a video clip to tensorboard.
This requires moviepy as a dependency, since the video is encoded as a GIF.
The video will appear under the 'Images' tab in the web browser.

Known Issues:
- the gif creation has an annoying progress bar print, which I'm trying to remove.

Cheers,
D