### PR TITLE
fix: Closing SummaryWriter closes the event file

### DIFF
--- a/tensorboardX/event_file_writer.py
+++ b/tensorboardX/event_file_writer.py
@@ -82,6 +82,7 @@ class EventsWriter(object):
     def close(self):
         '''Call self.flush().'''
         return_value = self.flush()
+        self._py_recordio_writer.close()
         return return_value
 
 

--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -30,6 +30,9 @@ class RecordWriter(object):
         w(struct.pack('I', masked_crc32c(event_str)))
         self._writer.flush()
 
+    def close(self):
+        self._writer.close()
+
 
 def masked_crc32c(data):
     x = u32(crc32c(data))

--- a/tests/test_summary_writer.py
+++ b/tests/test_summary_writer.py
@@ -6,3 +6,17 @@ def test_summary_writer_ctx():
     with SummaryWriter() as writer:
         writer.add_scalar('test', 1)
     assert writer.file_writer is None
+
+
+def test_summary_writer_close():
+    # Opening and closing SummaryWriter a lot should not run into
+    # OSError: [Errno 24] Too many open files
+    passed = True
+    try:
+        for i in range(10000):
+            writer = SummaryWriter()
+            writer.close()
+    except OSError:
+        passed = False
+
+    assert passed


### PR DESCRIPTION
* Make sure calling .close() on SummaryWriter also closes the event
  file.

* Fixes #108

Signed-off-by: mr.Shu <mr@shu.io>