### PR TITLE
Switch to agg backend for matplotlib.pyplot to work properly

### DIFF
--- a/examples/matplotlib_demo.py
+++ b/examples/matplotlib_demo.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-
+plt.switch_backend('agg')
 
 fig = plt.figure()
 


### PR DESCRIPTION
This demo doesn't work on my Linux machine because it doesn't declare a backend for matplotlib. With this change it can now work on my server. This seems to be a common issue as described here: https://github.com/matplotlib/matplotlib/issues/3466/#issuecomment-195899517