### PR TITLE
Fix Numpy future warning

### DIFF
--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -374,7 +374,7 @@ class SummaryWriter(object):
         """
         if self._check_caffe2(values):
             values = workspace.FetchBlob(values)
-        if isinstance(bins, str) and bins == 'tensorflow':
+        if isinstance(bins, six.string_types) and bins == 'tensorflow':
             bins = self.default_bins
         self.file_writer.add_summary(histogram(tag, values, bins), global_step)
 

--- a/tensorboardX/writer.py
+++ b/tensorboardX/writer.py
@@ -374,7 +374,7 @@ class SummaryWriter(object):
         """
         if self._check_caffe2(values):
             values = workspace.FetchBlob(values)
-        if bins == 'tensorflow':
+        if isinstance(bins, str) and bins == 'tensorflow':
             bins = self.default_bins
         self.file_writer.add_summary(histogram(tag, values, bins), global_step)
 


### PR DESCRIPTION
Numpy supports bins given by an array of edges. In this case `bins == 'tensorflow'` comparison yields the following warning:

> FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison

This commit makes sure that non-string bins are not compared with 'tensorflow' string.